### PR TITLE
[PLA-1593] add reset password cases

### DIFF
--- a/resources/js/components/pages/auth/ResetPassword.vue
+++ b/resources/js/components/pages/auth/ResetPassword.vue
@@ -48,6 +48,7 @@ import EnjinLogo from '~/components/EnjinLogo.vue';
 import { AuthApi } from '~/api/auth';
 import snackbar from '~/util/snackbar';
 import { snackbarErrors } from '~/util';
+import { ResetPasswordResponse } from '~/types/types.enums';
 
 const router = useRouter();
 const route = useRoute();
@@ -90,11 +91,13 @@ const resetPassword = async () => {
     isLoading.value = true;
     try {
         const res = await AuthApi.resetPassword(email.value, password.value, confirmPassword.value, props.token);
-        if (res.data.ResetPassword === true) {
+        if (res.data.ResetPassword === ResetPasswordResponse.PASSWORD_RESET) {
             snackbar.success({ title: 'Password reset successfully.', save: false });
             redirectToLogin();
-        } else {
-            snackbar.error({ title: 'Error resetting password.' });
+        } else if (res.data.ResetPassword === ResetPasswordResponse.INVALID_TOKEN) {
+            snackbar.error({ title: 'Invalid token' });
+        } else if (res.data.ResetPassword === ResetPasswordResponse.INVALID_USER) {
+            snackbar.error({ title: 'Invalid user', text: 'Please check the email provided' });
         }
     } catch (e) {
         if (snackbarErrors(e)) return;

--- a/resources/js/types/types.enums.ts
+++ b/resources/js/types/types.enums.ts
@@ -129,3 +129,9 @@ export enum RuleType {
     TANK_FUEL_BUDGET = 'TANK_FUEL_BUDGET',
     REQUIRE_TOKEN = 'REQUIRE_TOKEN',
 }
+
+export enum ResetPasswordResponse {
+    PASSWORD_RESET = 'PASSWORD_RESET',
+    INVALID_TOKEN = 'INVALID_TOKEN',
+    INVALID_USER = 'INVALID_USER',
+}

--- a/src/Console/InstallPlatformUi.php
+++ b/src/Console/InstallPlatformUi.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Str;
 
 class InstallPlatformUi extends Command
 {
-    protected $signature = 'platform-ui:install {--host=} {--token=} {--route=} {--tenant=} {--wsurl=} {--wschannel=} {--skip}';
+    protected $signature = 'platform-ui:install {--tenant=} {--route=} {--wsurl=} {--wschannel=} {--skip}';
 
     protected $description = 'Install the Platform UI package';
     private $BASE_DIR = __DIR__ . '/../../';

--- a/src/Console/RebuildPlatformUi.php
+++ b/src/Console/RebuildPlatformUi.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Enjin\PlatformUi\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Str;
+
+class RebuildPlatformUi extends Command
+{
+    protected $signature = 'platform-ui:rebuild';
+
+    protected $description = 'Rebuild the Platform UI package';
+    private $BASE_DIR = __DIR__ . '/../../';
+
+    public function handle()
+    {
+        $this->comment('Installing Platform UI dependencies...');
+        exec('npm install --prefix ' . $this->BASE_DIR . ' 2> /dev/null');
+
+        $this->comment('Building Platform UI...');
+        exec('npm run prod-laravel --prefix ' . $this->BASE_DIR . ' 2> /dev/null');
+
+        $this->comment('Publishing Platform UI Assets...');
+        $this->callSilent('vendor:publish', ['--tag' => 'platform-ui-assets', '--force' => true]);
+
+        $this->info('Platform UI package Installed successfully.');
+    }
+}

--- a/src/PlatformUiServiceProvider.php
+++ b/src/PlatformUiServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Enjin\PlatformUi;
 
 use Enjin\PlatformUi\Console\InstallPlatformUi;
+use Enjin\PlatformUi\Console\RebuildPlatformUi;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
 
@@ -18,7 +19,8 @@ class PlatformUiServiceProvider extends PackageServiceProvider
             ->hasConfigFile(['enjin-platform-ui'])
             ->hasRoute('web')
             ->hasAssets()
-            ->hasCommand(InstallPlatformUi::class);
+            ->hasCommand(InstallPlatformUi::class)
+            ->hasCommand(RebuildPlatformUi::class);
     }
 
     /**


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Introduced `ResetPasswordResponse` enum to standardize responses for reset password operations.
- Enhanced error handling in `ResetPassword.vue` by providing specific messages for different failure scenarios, such as invalid token or user.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ResetPassword.vue
</strong><dd><code>Enhance Reset Password Response Handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

resources/js/components/pages/auth/ResetPassword.vue
<li>Utilized <code>ResetPasswordResponse</code> enum for handling reset password <br>responses.<br> <li> Added specific error messages for invalid token and invalid user <br>scenarios.<br>


</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-ui/pull/78/files#diff-99201835fa1263ec1e977660de72805e144dc36493c48f72a199474cceede8fb"></a></td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>types.enums.ts
</strong><dd><code>Add ResetPasswordResponse Enum</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

resources/js/types/types.enums.ts
<li>Added <code>ResetPasswordResponse</code> enum with <code>PASSWORD_RESET</code>, <code>INVALID_TOKEN</code>, <br>and <code>INVALID_USER</code> values.<br>


</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-ui/pull/78/files#diff-bd7bee1a43a4ac33001fda56c8dbdd0dc0e79fa2d9adb9b38be75a8ddbebf378"></a></td>
</tr>                    
</table></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. The tool can be triggered [automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) every time a new PR is opened, or can be invoked manually by commenting on a PR.

When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app), use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation </strong></summary><hr>

- When you first install the app, the [default mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will keep the original title, and will add the original user description above the generated description. 

- Markers are an alternative way to control the generated description, to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in the PR description with the relevant content, where `marker_name` is one of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels </strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different possibilities. Define custom labels that are relevant for your repo and use cases.
Note that Labels are not mutually exclusive, so you can add multiple label categories.
Make sure to provide proper title, and a detailed and well-phrased description for each label, so the tool will know when to suggest it.        


</details></td></tr>

<tr><td><details> <summary><strong> Inline File Walkthrough 💎</strong></summary><hr>

For enhanced user experience, the `describe` tool can add file summaries directly to the "Files changed" tab in the PR page.
This will enable you to quickly understand the changes in each file, while reviewing the code changes (diffs).

To enable inline file summary, set `pr_description.inline_file_summary` in the configuration file, possible values are:
- `'table'`: File changes walkthrough table will be displayed on the top of the "Files changed" tab, in addition to the "Conversation" tab.
- `true`: A collapsable file comment with changes title and a changes summary for each file in the PR.
- `false` (default): File changes walkthrough will be added only to the "Conversation" tab.
<tr><td><details> <summary><strong> Utilizing extra instructions</strong></summary><hr>

The `describe` tool can be configured with extra instructions, to guide the model to a feedback tailored to the needs of your project.

Be specific, clear, and concise in the instructions. With extra instructions, you are the prompter. Notice that the general structure of the description is fixed, and cannot be changed. Extra instructions can change the content or style of each sub-section of the PR description.

Examples for extra instructions:
```
[pr_description] 
extra_instructions="""
- The PR title should be in the format: '<PR type>: <title>'
- The title should be short and concise (up to 10 words)
- ...
"""
```
Use triple quotes to write multi-line instructions. Use bullet points to make the instructions more readable.


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent commands</strong></summary><hr> 

> To invoke the PR-Agent, add a comment using one of the following commands:  
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the contents of the PR.   
> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's contents.   
> - **/add_docs** 💎: Generate docstring for new components introduced in the PR.   
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's contents.   
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes walkthrough for each component.   

>See the [tools guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md) for more details.
>To list the possible configuration parameters, add a **/config** comment.   
 


</details></td></tr>

</table>

See the [describe usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md) page for a comprehensive guide on using this tool.


</details>
