### PR TITLE
[PLA-1758] fix fuel tank

### DIFF
--- a/resources/js/components/slideovers/fueltank/ConsumptionFuelTankSlideover.vue
+++ b/resources/js/components/slideovers/fueltank/ConsumptionFuelTankSlideover.vue
@@ -110,7 +110,7 @@ const formRef = ref();
 const validation = yup.object({
     tankId: stringRequiredSchema,
     ruleSetId: numberRequiredSchema.typeError('Rule Set ID must be a number'),
-    userId: stringRequiredSchema,
+    userId: stringNotRequiredSchema,
     totalConsumed: numberRequiredSchema.typeError('Total Consumed must be a number'),
     lastResetBlock: numberNotRequiredSchema.typeError('Last Reset Block must be a number'),
     idempotencyKey: stringNotRequiredSchema,

--- a/resources/js/components/slideovers/fueltank/MutateFuelTankSlideover.vue
+++ b/resources/js/components/slideovers/fueltank/MutateFuelTankSlideover.vue
@@ -119,6 +119,12 @@ import { addressToPublicKey } from '~/util/address';
 import { TokenIdType } from '~/types/types.interface';
 import { useAppStore } from '~/store';
 import FormSelect from '~/components/FormSelect.vue';
+import {
+    booleanNotRequiredSchema,
+    booleanRequiredSchema,
+    stringNotRequiredSchema,
+    stringRequiredSchema,
+} from '~/util/schemas';
 
 const emit = defineEmits(['close']);
 
@@ -166,14 +172,18 @@ const removeCaller = (index: number) => {
 };
 
 const validation = yup.object({
-    tankId: yup.string().required(),
-    providesDeposit: yup.boolean().required(),
-    reservesExistentialDeposit: yup.boolean(),
-    reservesAccountCreationDeposit: yup.boolean(),
-    whitelistedCallers: yup.string().nullable(),
-    collectionId: yup.string().nullable(),
-    tokenId: yup.string().nullable(),
-    idempotencyKey: yup.string().nullable(),
+    tankId: stringRequiredSchema,
+    providesDeposit: booleanRequiredSchema,
+    reservesExistentialDeposit: booleanNotRequiredSchema,
+    reservesAccountCreationDeposit: booleanNotRequiredSchema,
+    whitelistedCallers: yup.array().of(
+        yup.object({
+            caller: stringRequiredSchema,
+        })
+    ),
+    collectionId: stringNotRequiredSchema,
+    tokenId: stringNotRequiredSchema,
+    idempotencyKey: stringNotRequiredSchema,
 });
 
 const mutateFuelTank = async () => {
@@ -190,7 +200,7 @@ const mutateFuelTank = async () => {
                     reservesExistentialDeposit: reservesExistentialDeposit.value,
                     reservesAccountCreationDeposit: reservesAccountCreationDeposit.value,
                     accountRules: {
-                        whitelistedCallers: whitelistedCallers.value.map((item: any) => item.caller),
+                        whitelistedCallers: formatData(whitelistedCallers.value.map((item: any) => item.caller)),
                         requireToken: collectionId.value
                             ? {
                                   collectionId: collectionId.value,


### PR DESCRIPTION
### **PR Type**
enhancement, bug_fix


___

### **Description**
- Updated the `userId` field to be optional in `ConsumptionFuelTankSlideover.vue`, enhancing flexibility in user ID handling.
- Refactored and enhanced the validation schemas in `MutateFuelTankSlideover.vue`, including changes to boolean fields and array handling for `whitelistedCallers`.
- Improved data formatting for token IDs and caller lists, ensuring better data integrity and error handling.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ConsumptionFuelTankSlideover.vue</strong><dd><code>Update validation schema for ConsumptionFuelTank</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

resources/js/components/slideovers/fueltank/ConsumptionFuelTankSlideover.vue
- Changed the schema for `userId` from required to not required.



</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-ui/pull/106/files#diff-5e3745746e7e57731be19c6581339bb9cbe271d05ed8059e59d63b6f41ae9ba2">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>MutateFuelTankSlideover.vue</strong><dd><code>Refactor and enhance validation in MutateFuelTankSlideover</code></dd></summary>
<hr>

resources/js/components/slideovers/fueltank/MutateFuelTankSlideover.vue
<li>Introduced new schema imports for boolean and string validations.<br> <li> Updated the validation schema for various fields like <code>tankId</code>, <br><code>providesDeposit</code>, and <code>whitelistedCallers</code>.<br> <li> Enhanced data formatting for <code>whitelistedCallers</code> and <code>tokenId</code> in the <br><code>mutateFuelTank</code> function.<br>


</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-ui/pull/106/files#diff-0ab2c26feeb26a19d6e9651ee83d76f99ad04853c78c4ac532ce5ffe06e6aa58">+19/-9</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

