### PR TITLE
[PLA-1911] fix collection tracked

### DIFF
--- a/resources/js/factory/collection.ts
+++ b/resources/js/factory/collection.ts
@@ -7,7 +7,7 @@ export class DTOCollectionFactory {
         const accounts: string[] = useAppStore().user?.walletAccounts ?? [];
         let tracked = false;
         if (accounts.length && useAppStore().isMultiTenant) {
-            tracked = !accounts.some((account) => account === collection.owner.account.publicKey);
+            tracked = !accounts.find((account) => account === publicKeyToAddress(collection.owner.account.publicKey));
         }
 
         return {


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed the logic for tracking collections by changing the method from `some` to `find` for account comparison.
- Added conversion of public key to address using `publicKeyToAddress` function to ensure proper comparison.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>collection.ts</strong><dd><code>Fix account tracking logic in collection factory</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

resources/js/factory/collection.ts

<li>Changed <code>some</code> method to <code>find</code> method for account comparison.<br> <li> Utilized <code>publicKeyToAddress</code> function for public key conversion.<br>


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-ui/pull/141/files#diff-01445672db13264dbc1cebd0222d1ec1fa064c874735b3d6ef7be31f335a040f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

