### PR TITLE
[PLA-1911] fix tracking with daemon account

### DIFF
--- a/resources/js/factory/collection.ts
+++ b/resources/js/factory/collection.ts
@@ -13,7 +13,7 @@ export class DTOCollectionFactory {
             accounts.push(publicKeyToAddress(appStore.user?.account));
         }
 
-        if (appStore.config.daemon) {
+        if (appStore.config.daemon && !appStore.isMultiTenant) {
             accounts.push(publicKeyToAddress(appStore.config.daemon));
         }
 


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Added a condition to check `appStore.isMultiTenant` before pushing the daemon account in `DTOCollectionFactory`.
- This fix ensures that the daemon account is not tracked in multi-tenant setups.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>collection.ts</strong><dd><code>Fix daemon account tracking for multi-tenant setups</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

resources/js/factory/collection.ts

<li>Added a condition to check <code>appStore.isMultiTenant</code> before pushing the <br>daemon account.<br>


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-ui/pull/151/files#diff-01445672db13264dbc1cebd0222d1ec1fa064c874735b3d6ef7be31f335a040f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

