### PR TITLE
[PLA-1934] tracking snackbar

### DIFF
--- a/resources/js/components/pages/Collections.vue
+++ b/resources/js/components/pages/Collections.vue
@@ -427,6 +427,11 @@ const trackCollection = async (collectionId: string) => {
     try {
         await CollectionApi.trackCollection(collectionId);
         await getCollections();
+        snackbar.success({
+            title: 'Tracking',
+            text: 'Collection tracked successfully',
+            save: false,
+        });
     } catch {
         snackbar.info({
             title: 'Tracking',
@@ -447,6 +452,11 @@ const untrackCollection = async () => {
             return;
         } else {
             await getCollections();
+            snackbar.success({
+                title: 'Untracking',
+                text: 'Collection untracked successfully',
+                save: false,
+            });
         }
     } catch {
         snackbar.info({

--- a/resources/js/components/pages/Collections.vue
+++ b/resources/js/components/pages/Collections.vue
@@ -126,7 +126,7 @@
                                         v-if="collection.tracked"
                                         text="Tracked"
                                         :closable="false"
-                                        class="!bg-blue-400 !bg-opacity-80 !text-white"
+                                        class="absolute right-16 top-3 !bg-blue-400 !bg-opacity-80 !text-white"
                                     />
                                     <LoadingCircle
                                         class="mx-3 h-5 w-5"
@@ -154,7 +154,7 @@
             key="cancel"
             :is-open="untrackModal"
             title="Untrack Collection"
-            description="Are you sure you want to untrack this collection? it will be removed from your collections list and you will have to add it again"
+            description="Are you sure you want to untrack this collection? It will be removed from your collections' list and you will have to add it again."
             @closed="closeUntrackModal"
             @confirm="untrackCollection"
         />


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Adjusted the position of the `Tracked` chip to be absolute and positioned at the top right.
- Corrected the description text in the `Untrack Collection` modal for better readability.
- Added success snackbar notifications for both tracking and untracking collections to improve user feedback.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Collections.vue</strong><dd><code>UI and UX improvements for tracking and untracking collections</code></dd></summary>
<hr>

resources/js/components/pages/Collections.vue

<li>Adjusted the position of the <code>Tracked</code> chip.<br> <li> Corrected the description text in the <code>Untrack Collection</code> modal.<br> <li> Added success snackbar notifications for tracking and untracking <br>collections.<br>


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-ui/pull/152/files#diff-fa057c3b15bcc7a3a36a2664cdf4d7aecc0f7d2abfb6d89c0fa9a2d1e3f6ff2e">+12/-2</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

