### PR TITLE
[PLA-2042] fix track collection loading

### DIFF
--- a/resources/js/components/TrackCollectionModal.vue
+++ b/resources/js/components/TrackCollectionModal.vue
@@ -63,5 +63,5 @@ watch(
             loading.value = false;
         }
     }
-)
+);
 </script>

--- a/resources/js/components/TrackCollectionModal.vue
+++ b/resources/js/components/TrackCollectionModal.vue
@@ -31,7 +31,7 @@ import { DialogTitle } from '@headlessui/vue';
 import Btn from '~/components/Btn.vue';
 import Modal from '~/components/Modal.vue';
 import FormInput from './FormInput.vue';
-import { onMounted, ref } from 'vue';
+import { onMounted, ref, watch } from 'vue';
 
 const props = defineProps<{ isOpen: boolean }>();
 
@@ -54,4 +54,14 @@ onMounted(() => {
     collectionId.value = '';
     loading.value = false;
 });
+
+watch(
+    () => props.isOpen,
+    (isOpen) => {
+        if (!isOpen) {
+            collectionId.value = '';
+            loading.value = false;
+        }
+    }
+)
 </script>


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed an issue with track collection loading by adding a watcher on the `isOpen` prop to reset the `collectionId` and `loading` state when the modal is closed.
- Imported `watch` from Vue to implement the new functionality.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TrackCollectionModal.vue</strong><dd><code>Fix track collection loading by resetting state on close</code>&nbsp; </dd></summary>
<hr>

resources/js/components/TrackCollectionModal.vue

<li>Added <code>watch</code> from Vue to monitor <code>isOpen</code> prop.<br> <li> Reset <code>collectionId</code> and <code>loading</code> when modal is closed.<br>


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-ui/pull/167/files#diff-85a0c5c7e789b8fc74110ade171ee47137091fc67326b918acf2e9aeaf72b392">+11/-1</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information