### PR TITLE
[PLA-2049] remove keepalive from transfer forms

### DIFF
--- a/resources/js/components/batch/forms/BatchTransferForm.vue
+++ b/resources/js/components/batch/forms/BatchTransferForm.vue
@@ -95,7 +95,6 @@ import { ref, computed, watch } from 'vue';
 import { Form } from 'vee-validate';
 import * as yup from 'yup';
 import FormInput from '~/components/FormInput.vue';
-import FormCheckbox from '~/components/FormCheckbox.vue';
 import { addressToPublicKey, publicKeyToAddress } from '~/util/address';
 import { formatData, formatToken, parseFormatedTokenId, validateToken } from '~/util';
 import { TokenIdSelectType } from '~/types/types.enums';
@@ -105,13 +104,10 @@ import RadioGroupButton from '~/components/RadioGroupButton.vue';
 import FadeTransition from '~/components/FadeTransition.vue';
 import {
     addressRequiredSchema,
-    booleanNotRequiredSchema,
-    booleanRequiredSchema,
     numberRequiredSchema,
     stringNotRequiredSchema,
     stringRequiredSchema,
 } from '~/util/schemas';
-import { useAppStore } from '~/store';
 import Tooltip from '~/components/Tooltip.vue';
 import { QuestionMarkCircleIcon } from '@heroicons/vue/24/outline';
 import snackbar from '~/util/snackbar';

--- a/resources/js/components/batch/forms/BatchTransferForm.vue
+++ b/resources/js/components/batch/forms/BatchTransferForm.vue
@@ -34,13 +34,6 @@
                         type="number"
                         required
                     />
-                    <FormCheckbox
-                        v-if="useAppStore().advanced"
-                        v-model="simpleKeepAlive"
-                        name="simpleKeepAlive"
-                        label="Keep Alive"
-                        description="If true, the transaction will fail if the balance drops below the minimum requirement. Defaults to False."
-                    />
                 </div>
             </div>
             <div class="rounded-b-lg p-6 pt-0" v-else>
@@ -90,13 +83,6 @@
                         description="The amount to transfer."
                         type="number"
                         required
-                    />
-                    <FormCheckbox
-                        v-if="useAppStore().advanced"
-                        v-model="operatorKeepAlive"
-                        name="operatorKeepAlive"
-                        label="Keep Alive"
-                        description="If true, the transaction will fail if the balance drops below the minimum requirement. Defaults to False."
                     />
                 </div>
             </div>
@@ -165,8 +151,6 @@ const operatorTokenId = ref(
 );
 const simpleAmount = ref(props.modelValue.simpleParams?.amount ?? 1);
 const operatorAmount = ref(props.modelValue.operatorParams?.amount ?? 1);
-const simpleKeepAlive = ref(props.modelValue.simpleParams?.keepAlive ?? false);
-const operatorKeepAlive = ref(props.modelValue.operatorParams?.keepAlive ?? false);
 const operatorSource = ref(props.modelValue.operatorParams?.source!);
 
 const validForm = computed(() => formRef.value.getMeta().valid);
@@ -178,7 +162,6 @@ const operatorValidation = yup.object({
     operatorTokenId: stringRequiredSchema.typeError('Token ID is required'),
     operatorAmount: numberRequiredSchema.typeError('Amount must be a number'),
     operatorSource: stringRequiredSchema,
-    operatorKeepAlive: booleanNotRequiredSchema,
 });
 
 const simpleValidation = yup.object({
@@ -186,7 +169,6 @@ const simpleValidation = yup.object({
     transferType: stringNotRequiredSchema,
     simpleTokenId: stringRequiredSchema.typeError('Token ID is required'),
     simpleAmount: numberRequiredSchema.typeError('Amount must be a number'),
-    simpleKeepAlive: booleanRequiredSchema,
 });
 
 const hasChanged = computed(() =>
@@ -198,7 +180,6 @@ const hasChanged = computed(() =>
                 ? {
                       tokenId: formatToken(simpleTokenId.value),
                       amount: simpleAmount.value,
-                      keepAlive: simpleKeepAlive.value,
                   }
                 : null,
         operatorParams:
@@ -207,7 +188,6 @@ const hasChanged = computed(() =>
                       tokenId: formatToken(operatorTokenId.value),
                       source: addressToPublicKey(operatorSource.value),
                       amount: operatorAmount.value,
-                      keepAlive: operatorKeepAlive.value,
                   }
                 : null,
     })

--- a/resources/js/components/slideovers/token/TransferTokenSlideover.vue
+++ b/resources/js/components/slideovers/token/TransferTokenSlideover.vue
@@ -60,12 +60,6 @@
                             type="number"
                             required
                         />
-                        <FormCheckbox
-                            v-model="keepAlive"
-                            name="keepAlive"
-                            label="Keep Alive"
-                            description="If true, the transaction will fail if the balance drops below the minimum requirement. Defaults to False."
-                        />
                         <FormInput
                             v-model="signingAccount"
                             name="signingAccount"
@@ -146,7 +140,6 @@ const collectionId = ref(props.item?.collectionId);
 const recipient = ref('');
 const source = ref('');
 const amount = ref();
-const keepAlive = ref(false);
 const signingAccount = ref('');
 const idempotencyKey = ref('');
 const skipValidation = ref(false);
@@ -164,7 +157,6 @@ const validation = yup.object({
     recipient: addressRequiredSchema,
     amount: numberRequiredSchema.min(1),
     source: stringNotRequiredSchema,
-    keepAlive: booleanNotRequiredSchema,
     signingAccount: stringNotRequiredSchema,
     idempotencyKey: stringNotRequiredSchema,
     skipValidation: booleanNotRequiredSchema,
@@ -193,7 +185,6 @@ const transferToken = async () => {
                     tokenId: formatToken(tokenId.value),
                     source: source.value,
                     amount: amount.value,
-                    keepAlive: keepAlive.value,
                 },
                 signingAccount: signingAccount.value,
                 idempotencyKey: idempotencyKey.value,


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Removed the `Keep Alive` option from the `BatchTransferForm` and `TransferTokenSlideover` components.
- Deleted all references to `keepAlive` in the form data and validation schemas.
- Simplified the form structure by removing unnecessary fields.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BatchTransferForm.vue</strong><dd><code>Remove Keep Alive option from BatchTransferForm</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

resources/js/components/batch/forms/BatchTransferForm.vue

<li>Removed <code>Keep Alive</code> checkbox from the form.<br> <li> Deleted <code>simpleKeepAlive</code> and <code>operatorKeepAlive</code> references.<br> <li> Updated validation schemas to remove <code>keepAlive</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-ui/pull/170/files#diff-e61d7f7357fb38ebfd6ba9e3420c0f355f3c372e5ec8cc13bf0a2078c8fb524b">+0/-20</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>TransferTokenSlideover.vue</strong><dd><code>Remove Keep Alive option from TransferTokenSlideover</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

resources/js/components/slideovers/token/TransferTokenSlideover.vue

<li>Removed <code>Keep Alive</code> checkbox from the form.<br> <li> Deleted <code>keepAlive</code> reference.<br> <li> Updated validation schema to remove <code>keepAlive</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-ui/pull/170/files#diff-af2c520b420972c0d8d8c1d7dcb2ffc949a07458d9abb40989ae9e5480852b1d">+0/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information