### PR TITLE
[PLA-2065] fix infuse token mutation

### DIFF
--- a/resources/js/graphql/mutation/token/InfuseToken.ts
+++ b/resources/js/graphql/mutation/token/InfuseToken.ts
@@ -1,5 +1,5 @@
 export default `mutation InfuseToken($collectionId: BigInt!, $tokenId: EncodableTokenIdInput!, $amount: BigInt!, $signingAccount: String, $idempotencyKey: String, $skipValidation: Boolean! = false) {
-    InfuseToken(
+    Infuse(
       collectionId: $collectionId
       tokenId: $tokenId
       amount: $amount


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Renamed the GraphQL mutation `InfuseToken` to `Infuse` to fix a naming issue.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>InfuseToken.ts</strong><dd><code>Rename mutation from `InfuseToken` to `Infuse`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

resources/js/graphql/mutation/token/InfuseToken.ts

- Renamed the `InfuseToken` mutation to `Infuse`.



</details>


  </td>
  <td><a href="https://github.com/enjin/platform-ui/pull/174/files#diff-02a79f4915887135f94ec6c6934bb09512f19f796d56c2b49fe316b25f567d15">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information