### PR TITLE
[PLA-2075] fix freeze fueltank modal

### DIFF
--- a/resources/js/components/slideovers/fueltank/FreezeFuelTankSlideover.vue
+++ b/resources/js/components/slideovers/fueltank/FreezeFuelTankSlideover.vue
@@ -7,7 +7,7 @@
         @submit="freezeFuelTank"
     >
         <h3 class="text-xl font-semibold px-4 sm:px-6 py-4 text-light-content-strong dark:text-dark-content-strong">
-            Freeze Fuel Tank
+            {{ props.item?.isFrozen ? 'Unfreeze' : 'Freeze' }} Fuel Tank
         </h3>
         <div class="h-0 flex-1 overflow-y-auto">
             <div class="flex flex-1 flex-col justify-between">
@@ -49,7 +49,7 @@
         </div>
         <div class="flex space-x-3 flex-shrink-0 justify-end px-4 py-4">
             <Btn @click="closeSlide">Cancel</Btn>
-            <Btn :loading="isLoading" :disabled="isLoading" primary is-submit>Freeze</Btn>
+            <Btn :loading="isLoading" :disabled="isLoading" primary is-submit>Confirm</Btn>
         </div>
     </Form>
 </template>
@@ -91,7 +91,7 @@ const props = withDefaults(
 
 const isLoading = ref(false);
 const tankId = ref(props.item?.tankId);
-const isFrozen = ref(false);
+const isFrozen = ref(props.item?.isFrozen ?? false);
 const ruleSetId = ref();
 const idempotencyKey = ref('');
 const formRef = ref();
@@ -131,8 +131,8 @@ const freezeFuelTank = async () => {
 
         if (id) {
             snackbar.success({
-                title: 'Fuel Tank freeze',
-                text: `Fuel Tank frozen with transaction id ${id}`,
+                title: `Fuel Tank ${props.item?.isFrozen ? 'Unfreeze' : 'Freeze'} `,
+                text: `Fuel Tank ${props.item?.isFrozen ? 'Unfreeze' : 'Freeze'} with transaction id ${id}`,
                 event: id,
             });
             closeSlide();
@@ -140,8 +140,8 @@ const freezeFuelTank = async () => {
     } catch (e) {
         if (snackbarErrors(e)) return;
         snackbar.error({
-            title: 'Fuel Tank freeze',
-            text: 'Fuel Tank freeze failed',
+            title: `Fuel Tank ${props.item?.isFrozen ? 'Unfreeze' : 'Freeze'}`,
+            text: `Fuel Tank ${props.item?.isFrozen ? 'Unfreeze' : 'Freeze'} failed`,
         });
     } finally {
         isLoading.value = false;


### PR DESCRIPTION
### **PR Type**
enhancement, bug fix


___

### **Description**
- Enhanced the Fuel Tank Slideover component to dynamically handle both freezing and unfreezing actions based on the current state of the fuel tank.
- Updated UI elements such as titles and button text to reflect the dynamic nature of the action.
- Improved user feedback by modifying snackbar messages to indicate whether the action was a freeze or unfreeze.
- Fixed initialization of the `isFrozen` state to correctly reflect the current state of the fuel tank.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>FreezeFuelTankSlideover.vue</strong><dd><code>Dynamic freeze/unfreeze functionality for Fuel Tank Slideover</code></dd></summary>
<hr>

resources/js/components/slideovers/fueltank/FreezeFuelTankSlideover.vue

<li>Updated the title to dynamically display 'Freeze' or 'Unfreeze' based <br>on the fuel tank state.<br> <li> Changed button text from 'Freeze' to 'Confirm'.<br> <li> Modified snackbar messages to reflect dynamic 'Freeze' or 'Unfreeze' <br>actions.<br> <li> Initialized <code>isFrozen</code> state based on the <code>props.item</code> value.<br>


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-ui/pull/176/files#diff-5957da1135f599d727acf823d90a741bf8aadb9dc9bdacd932edf6ad7e9bc78b">+7/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information