### PR TITLE
[PLA-3113] remove required image from batch mint

### DIFF
--- a/resources/js/components/batch/forms/BatchMintForm.vue
+++ b/resources/js/components/batch/forms/BatchMintForm.vue
@@ -28,7 +28,6 @@
                         label="Image URL"
                         class="w-full"
                         description="The URL of the image for the token."
-                        required
                     />
                     <FormInput
                         v-model="name"


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Removed the `required` attribute from the `imageUrl` field in the batch mint form.

- Ensures the image URL is no longer mandatory during batch minting.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BatchMintForm.vue</strong><dd><code>Made image URL optional in batch mint form</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

resources/js/components/batch/forms/BatchMintForm.vue

<li>Removed the <code>required</code> attribute from the <code>imageUrl</code> field.<br> <li> Adjusted the batch mint form to make the image URL optional.


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-ui/pull/185/files#diff-59933e552a3a49960bbfda04cdc29b388929d238d37da749de4c65509c734e3e">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information